### PR TITLE
Fixing update request generated by perseo

### DIFF
--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -108,6 +108,9 @@ function buildUpdateOptions(action, event) {
         //The portal does not provide 'type' for attribute, "plain" rules could
         if (action.parameters.attributes[i].type !== undefined) {
             attr.type = myutils.expandVar(action.parameters.attributes[i].type, event);
+        } else if ((attr.name + '__type') in event) {
+          // If not defined by rule, just copy it from the received event
+          attr.type = event[attr.name + '__type'];
         }
 
         attr.metadatas = [timeInstantMeta];


### PR DESCRIPTION
This PR fixes a situation where perseo would not include the attribute type specification in the update request to orion. Without including that, nothing but strings could be updated.

This commit fixes dojot/mashup#21